### PR TITLE
Add launch.config for VSCode users

### DIFF
--- a/Source/AmbientRoomMonitor/.vscode/launch.config
+++ b/Source/AmbientRoomMonitor/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/AnalogClockFace/.vscode/launch.config
+++ b/Source/AnalogClockFace/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Connectivity/.vscode/launch.config
+++ b/Source/Connectivity/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/GalleryViewer/.vscode/launch.config
+++ b/Source/GalleryViewer/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/MoistureMeter/.vscode/launch.config
+++ b/Source/MoistureMeter/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/MorseCodeTrainer/.vscode/launch.config
+++ b/Source/MorseCodeTrainer/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/PlantMonitor/.vscode/launch.config
+++ b/Source/PlantMonitor/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Simon/.vscode/launch.config
+++ b/Source/Simon/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/WaterStorageMonitor/.vscode/launch.config
+++ b/Source/WaterStorageMonitor/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/WifiWeather/.vscode/launch.config
+++ b/Source/WifiWeather/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}


### PR DESCRIPTION
Part of WildernessLabs/Meadow_Issues#236.

The addition of the `.vscode` folder doesn't appear to impact VS2022 users at all, even with several folders present in a solution.  I confirmed expected debug behavior using only the Blinky C# project, but it worked as expected.